### PR TITLE
Fix LangGraph Colab ART version pin

### DIFF
--- a/examples/langgraph/art-e-langgraph.ipynb
+++ b/examples/langgraph/art-e-langgraph.ipynb
@@ -74,7 +74,7 @@
         "        (\"vllm==0.9.2\", \"triton==3.2.0\") if is_t4 else (\"vllm\", \"triton\")\n",
         "    )\n",
         "    !uv pip install --upgrade \\\n",
-        "        openpipe-art[backend,langgraph]==0.4.11 langchain-core langgraph langchain_openai tenacity datasets pillow==11.3.0 protobuf==5.29.5 {get_vllm} {get_numpy} --prerelease allow --no-cache-dir\n",
+        "        openpipe-art[backend,langgraph]==0.5.9 langchain-core langgraph langchain_openai tenacity datasets pillow==11.3.0 protobuf==5.29.5 {get_vllm} {get_numpy} --prerelease allow --no-cache-dir\n",
         "    !uv pip install -qqq {get_triton}"
       ]
     },


### PR DESCRIPTION
## Summary
- updates the Colab install path in the ART-E LangGraph notebook from `openpipe-art[backend,langgraph]==0.4.11` to `==0.5.9`
- keeps the Colab and non-Colab install paths on the same ART release
- addresses the stale Colab dependency path behind the LangGraph notebook failure report

Fixes #13

/claim https://algora.io/PrimeIntellect-ai/bounties/YdTCEANzwx7HzgjQ

## Validation
- `jq empty examples/langgraph/art-e-langgraph.ipynb`
- `rg -n "openpipe-art\[backend,langgraph\]==" examples/langgraph/art-e-langgraph.ipynb pyproject.toml`
- `git diff --check`

## Limitations
- I did not run the full Colab/GPU training loop locally; this PR validates the notebook JSON and the dependency pin consistency only.